### PR TITLE
Add Firebase initialization module

### DIFF
--- a/firebase.js
+++ b/firebase.js
@@ -1,0 +1,23 @@
+import { initializeApp } from "firebase/app";
+import { getAuth } from "firebase/auth";
+import { getFirestore, serverTimestamp } from "firebase/firestore";
+
+// Placeholder Firebase configuration - replace with your project's config values
+const firebaseConfig = {
+  apiKey: "YOUR_API_KEY",
+  authDomain: "YOUR_AUTH_DOMAIN",
+  projectId: "YOUR_PROJECT_ID",
+  storageBucket: "YOUR_STORAGE_BUCKET",
+  messagingSenderId: "YOUR_MESSAGING_SENDER_ID",
+  appId: "YOUR_APP_ID",
+};
+
+// Initialize Firebase
+const app = initializeApp(firebaseConfig);
+
+// Initialize services
+const auth = getAuth(app);
+const db = getFirestore(app);
+
+// Export services and timestamp helper
+export { auth, db, serverTimestamp };


### PR DESCRIPTION
## Summary
- add Firebase v9 modular initialization with auth, Firestore, and server timestamp helper

## Testing
- `node --check firebase.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68919f7a0e908331a56be1a3aac71efa