### PR TITLE
feat: add Firestore chat utilities

### DIFF
--- a/firestore/chats.js
+++ b/firestore/chats.js
@@ -1,0 +1,81 @@
+import { getAuth } from 'firebase/auth';
+import {
+  addDoc,
+  collection,
+  onSnapshot,
+  query,
+  where,
+  orderBy,
+  updateDoc,
+  doc,
+  serverTimestamp,
+} from 'firebase/firestore';
+import { db } from '../firebase';
+
+const auth = getAuth();
+
+export async function createChat(participants, isGroup = false, groupName = '') {
+  const chatData = {
+    participants,
+    isGroup,
+    groupName: isGroup ? groupName : '',
+    createdAt: serverTimestamp(),
+    updatedAt: serverTimestamp(),
+    lastMessage: '',
+    lastMessageSender: '',
+  };
+
+  const chatRef = await addDoc(collection(db, 'chats'), chatData);
+  return chatRef.id;
+}
+
+export async function sendMessage(chatId, formattedText) {
+  const user = auth.currentUser;
+  if (!user) {
+    throw new Error('User not authenticated');
+  }
+
+  const text = formattedText.replace(/<[^>]*>/g, '');
+
+  await addDoc(collection(db, 'chats', chatId, 'messages'), {
+    senderId: user.uid,
+    senderName: user.displayName || '',
+    text,
+    formattedText,
+    createdAt: serverTimestamp(),
+  });
+
+  await updateDoc(doc(db, 'chats', chatId), {
+    lastMessage: text,
+    lastMessageSender: user.displayName || '',
+    updatedAt: serverTimestamp(),
+  });
+}
+
+export function listenToChats(callback) {
+  const user = auth.currentUser;
+  if (!user) return () => {};
+
+  const chatsQuery = query(
+    collection(db, 'chats'),
+    where('participants', 'array-contains', user.uid),
+    orderBy('updatedAt', 'desc')
+  );
+
+  return onSnapshot(chatsQuery, snapshot => {
+    const chats = snapshot.docs.map(docSnap => ({ id: docSnap.id, ...docSnap.data() }));
+    callback(chats);
+  });
+}
+
+export function listenToMessages(chatId, callback) {
+  const messagesQuery = query(
+    collection(db, 'chats', chatId, 'messages'),
+    orderBy('createdAt', 'asc')
+  );
+
+  return onSnapshot(messagesQuery, snapshot => {
+    const messages = snapshot.docs.map(docSnap => ({ id: docSnap.id, ...docSnap.data() }));
+    callback(messages);
+  });
+}


### PR DESCRIPTION
## Summary
- add Firestore chat helpers for creating chats, sending messages, and real-time listeners

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/ImpactTrack/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68919fc39e888331a0e455100cea1692