### PR TITLE
Add Firestore follow utilities

### DIFF
--- a/firestore/follows.js
+++ b/firestore/follows.js
@@ -1,0 +1,51 @@
+import { addDoc, collection, query, where, getDocs, deleteDoc } from 'firebase/firestore';
+import { getAuth } from 'firebase/auth';
+import { db } from '../firebase';
+
+export const followUser = async (targetUid) => {
+  const auth = getAuth();
+  const myUid = auth.currentUser?.uid;
+  if (!myUid) throw new Error('No authenticated user');
+
+  const createdAt = new Date();
+
+  await addDoc(collection(db, 'users', myUid, 'following'), {
+    followingUid: targetUid,
+    createdAt,
+  });
+
+  await addDoc(collection(db, 'users', targetUid, 'followers'), {
+    followerUid: myUid,
+    createdAt,
+  });
+};
+
+export const unfollowUser = async (targetUid) => {
+  const auth = getAuth();
+  const myUid = auth.currentUser?.uid;
+  if (!myUid) throw new Error('No authenticated user');
+
+  const followingQuery = query(
+    collection(db, 'users', myUid, 'following'),
+    where('followingUid', '==', targetUid)
+  );
+  const followingSnap = await getDocs(followingQuery);
+  await Promise.all(followingSnap.docs.map((doc) => deleteDoc(doc.ref)));
+
+  const followersQuery = query(
+    collection(db, 'users', targetUid, 'followers'),
+    where('followerUid', '==', myUid)
+  );
+  const followersSnap = await getDocs(followersQuery);
+  await Promise.all(followersSnap.docs.map((doc) => deleteDoc(doc.ref)));
+};
+
+export const getFollowers = async (uid) => {
+  const snap = await getDocs(collection(db, 'users', uid, 'followers'));
+  return snap.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+};
+
+export const getFollowing = async (uid) => {
+  const snap = await getDocs(collection(db, 'users', uid, 'following'));
+  return snap.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+};


### PR DESCRIPTION
## Summary
- add Firestore helper to follow and unfollow users
- expose utilities to fetch followers and following lists

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/ImpactTrack/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68919fc7a85083319daef5593d6952c7