### PR TITLE
Add activity logging dashboard

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Activity Dashboard</title>
+  <style>
+    body {
+      font-family: sans-serif;
+      margin: 2rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1.5rem;
+    }
+    form {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      align-items: center;
+    }
+    input,
+    select,
+    textarea,
+    button {
+      padding: 0.5rem;
+    }
+    ul {
+      list-style: none;
+      padding: 0;
+    }
+    li {
+      margin-bottom: 0.5rem;
+    }
+  </style>
+</head>
+<body>
+  <form id="activity-form">
+    <select id="type">
+      <option value="compost">Compost</option>
+      <option value="cleanup">Cleanup</option>
+    </select>
+    <input type="number" id="amount" placeholder="Amount" required />
+    <select id="unit">
+      <option value="kg">kg</option>
+      <option value="minutes">minutes</option>
+    </select>
+    <textarea id="note" placeholder="Note"></textarea>
+    <button type="submit">Log Activity</button>
+  </form>
+
+  <ul id="feed"></ul>
+
+  <script type="module" src="./dashboard.js"></script>
+</body>
+</html>

--- a/dashboard.js
+++ b/dashboard.js
@@ -1,0 +1,29 @@
+import { logActivity, getActivityFeed } from './firestore/activities.js';
+
+const form = document.getElementById('activity-form');
+const feedList = document.getElementById('feed');
+
+async function renderFeed() {
+  const feed = await getActivityFeed();
+  feedList.innerHTML = '';
+  feed.forEach((item) => {
+    const li = document.createElement('li');
+    li.textContent = `${item.username} logged ${item.amount} ${item.unit} of ${item.type}`;
+    feedList.appendChild(li);
+  });
+}
+
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const activity = {
+    type: document.getElementById('type').value,
+    amount: parseFloat(document.getElementById('amount').value),
+    unit: document.getElementById('unit').value,
+    note: document.getElementById('note').value,
+  };
+  await logActivity(activity);
+  form.reset();
+  renderFeed();
+});
+
+renderFeed();


### PR DESCRIPTION
## Summary
- Add dashboard HTML with activity logging form, minimal flex styling, and feed list
- Implement dashboard JS to import Firestore helpers, submit log events, and render feed

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/ImpactTrack/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68919fd16f7083319a95ec679f0cc79f