### PR TITLE
Add Firebase-based activity tracker MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # ImpactTrack
+
+ImpactTrack is a minimal activity tracker for composting and cleanup efforts. It uses Firebase for authentication and data storage.
+
+## Setup
+
+1. Create a Firebase project and enable Email/Password and Google sign-in providers.
+2. Update `firebase-config.js` with your project's configuration details.
+3. Host these static files or serve them locally (e.g., with `npx serve`).
+
+## Pages
+
+- `login.html` – Sign in or register using email/password or Google.
+- `index.html` – Log composting or cleanup activities and view recent entries.
+- `dashboard.html` – View personal and global statistics.
+
+## Firebase Security Rules
+
+See [firestore.rules](firestore.rules) for a basic starting point. Adjust as needed for your project.

--- a/dashboard.html
+++ b/dashboard.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ImpactTrack - Dashboard</title>
+</head>
+<body>
+  <h1>User Dashboard</h1>
+  <div id="user-stats"></div>
+  <h2>Global Dashboard</h2>
+  <div id="global-stats"></div>
+  <p><a href="index.html">Back to Tracker</a></p>
+  <button id="logout">Logout</button>
+
+  <script type="module" src="dashboard.js"></script>
+</body>
+</html>

--- a/dashboard.js
+++ b/dashboard.js
@@ -1,0 +1,56 @@
+import { auth, db } from './firebase-config.js';
+import { onAuthStateChanged, signOut } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
+import { collection, query, where, onSnapshot } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+
+const userStatsDiv = document.getElementById('user-stats');
+const globalStatsDiv = document.getElementById('global-stats');
+const logoutButton = document.getElementById('logout');
+let currentUser;
+
+onAuthStateChanged(auth, (user) => {
+  if (!user) {
+    window.location.href = 'login.html';
+  } else {
+    currentUser = user;
+    loadUserStats();
+    loadGlobalStats();
+  }
+});
+
+logoutButton.addEventListener('click', () => signOut(auth));
+
+function loadUserStats() {
+  const q = query(collection(db, 'activities'), where('userId', '==', currentUser.uid));
+  onSnapshot(q, (snapshot) => {
+    const stats = { compostKg: 0, cleanupKg: 0, compostMinutes: 0, cleanupMinutes: 0 };
+    snapshot.forEach((doc) => {
+      const data = doc.data();
+      if (data.type === 'compost') {
+        stats.compostKg += data.kg || 0;
+        stats.compostMinutes += data.minutes || 0;
+      } else if (data.type === 'cleanup') {
+        stats.cleanupKg += data.kg || 0;
+        stats.cleanupMinutes += data.minutes || 0;
+      }
+    });
+    userStatsDiv.textContent = `Compost: ${stats.compostKg} kg, ${stats.compostMinutes} min | Cleanup: ${stats.cleanupKg} kg, ${stats.cleanupMinutes} min`;
+  });
+}
+
+function loadGlobalStats() {
+  const q = query(collection(db, 'activities'));
+  onSnapshot(q, (snapshot) => {
+    const stats = { compostKg: 0, cleanupKg: 0, compostMinutes: 0, cleanupMinutes: 0 };
+    snapshot.forEach((doc) => {
+      const data = doc.data();
+      if (data.type === 'compost') {
+        stats.compostKg += data.kg || 0;
+        stats.compostMinutes += data.minutes || 0;
+      } else if (data.type === 'cleanup') {
+        stats.cleanupKg += data.kg || 0;
+        stats.cleanupMinutes += data.minutes || 0;
+      }
+    });
+    globalStatsDiv.textContent = `Compost: ${stats.compostKg} kg, ${stats.compostMinutes} min | Cleanup: ${stats.cleanupKg} kg, ${stats.cleanupMinutes} min`;
+  });
+}

--- a/firebase-config.js
+++ b/firebase-config.js
@@ -1,0 +1,17 @@
+import { initializeApp } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
+import { getAuth } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
+import { getFirestore } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+
+// TODO: Replace with your Firebase project's configuration
+const firebaseConfig = {
+  apiKey: "YOUR_API_KEY",
+  authDomain: "YOUR_AUTH_DOMAIN",
+  projectId: "YOUR_PROJECT_ID",
+  storageBucket: "YOUR_STORAGE_BUCKET",
+  messagingSenderId: "YOUR_MESSAGING_SENDER_ID",
+  appId: "YOUR_APP_ID"
+};
+
+const app = initializeApp(firebaseConfig);
+export const auth = getAuth(app);
+export const db = getFirestore(app);

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,10 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /activities/{activityId} {
+      allow read: if request.auth != null;
+      allow create: if request.auth != null && request.resource.data.userId == request.auth.uid;
+      allow update, delete: if request.auth != null && resource.data.userId == request.auth.uid;
+    }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ImpactTrack - Activity Tracker</title>
+</head>
+<body>
+  <h1>Activity Tracker</h1>
+  <form id="activity-form">
+    <label>
+      Activity:
+      <select id="activity-type">
+        <option value="compost">Composting</option>
+        <option value="cleanup">Cleanup</option>
+      </select>
+    </label>
+    <label>
+      Minutes:
+      <input type="number" id="minutes" min="0" />
+    </label>
+    <label>
+      Kilograms:
+      <input type="number" id="kg" min="0" step="0.01" />
+    </label>
+    <label>
+      Notes:
+      <input type="text" id="notes" />
+    </label>
+    <button type="submit">Log Activity</button>
+  </form>
+  <hr />
+  <h2>Activity Feed</h2>
+  <ul id="activity-feed"></ul>
+  <p>
+    <a href="dashboard.html">View Dashboard</a>
+  </p>
+  <button id="logout">Logout</button>
+
+  <script type="module" src="index.js"></script>
+</body>
+</html>

--- a/index.js
+++ b/index.js
@@ -1,0 +1,59 @@
+import { auth, db } from './firebase-config.js';
+import { signOut, onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
+import { collection, addDoc, query, where, orderBy, limit, onSnapshot, serverTimestamp } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+
+const activityForm = document.getElementById('activity-form');
+const activityFeed = document.getElementById('activity-feed');
+const logoutButton = document.getElementById('logout');
+
+let currentUser;
+
+onAuthStateChanged(auth, (user) => {
+  if (!user) {
+    window.location.href = 'login.html';
+  } else {
+    currentUser = user;
+    loadFeed();
+  }
+});
+
+activityForm.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  if (!currentUser) return;
+  const data = {
+    userId: currentUser.uid,
+    type: document.getElementById('activity-type').value,
+    minutes: Number(document.getElementById('minutes').value) || 0,
+    kg: Number(document.getElementById('kg').value) || 0,
+    notes: document.getElementById('notes').value,
+    createdAt: serverTimestamp()
+  };
+  try {
+    await addDoc(collection(db, 'activities'), data);
+    activityForm.reset();
+  } catch (err) {
+    alert(err.message);
+  }
+});
+
+logoutButton.addEventListener('click', () => {
+  signOut(auth);
+});
+
+function loadFeed() {
+  const q = query(
+    collection(db, 'activities'),
+    where('userId', '==', currentUser.uid),
+    orderBy('createdAt', 'desc'),
+    limit(10)
+  );
+  onSnapshot(q, (snapshot) => {
+    activityFeed.innerHTML = '';
+    snapshot.forEach((doc) => {
+      const data = doc.data();
+      const li = document.createElement('li');
+      li.textContent = `${data.type} - ${data.minutes} min - ${data.kg} kg - ${data.notes}`;
+      activityFeed.appendChild(li);
+    });
+  });
+}

--- a/login.html
+++ b/login.html
@@ -1,1 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ImpactTrack Login</title>
+</head>
+<body>
+  <h1>ImpactTrack</h1>
+  <h2>Login or Register</h2>
+  <form id="email-login">
+    <input type="email" id="email" placeholder="Email" required />
+    <input type="password" id="password" placeholder="Password" required />
+    <button type="submit">Login</button>
+    <button type="button" id="register">Register</button>
+  </form>
+  <hr />
+  <button id="google-login">Sign in with Google</button>
 
+  <script type="module" src="login.js"></script>
+</body>
+</html>

--- a/login.js
+++ b/login.js
@@ -1,1 +1,42 @@
+import { auth } from './firebase-config.js';
+import { signInWithEmailAndPassword, createUserWithEmailAndPassword, GoogleAuthProvider, signInWithPopup, onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
 
+const emailLoginForm = document.getElementById('email-login');
+const registerButton = document.getElementById('register');
+const googleButton = document.getElementById('google-login');
+
+emailLoginForm.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const email = document.getElementById('email').value;
+  const password = document.getElementById('password').value;
+  try {
+    await signInWithEmailAndPassword(auth, email, password);
+  } catch (err) {
+    alert(err.message);
+  }
+});
+
+registerButton.addEventListener('click', async () => {
+  const email = document.getElementById('email').value;
+  const password = document.getElementById('password').value;
+  try {
+    await createUserWithEmailAndPassword(auth, email, password);
+  } catch (err) {
+    alert(err.message);
+  }
+});
+
+googleButton.addEventListener('click', async () => {
+  const provider = new GoogleAuthProvider();
+  try {
+    await signInWithPopup(auth, provider);
+  } catch (err) {
+    alert(err.message);
+  }
+});
+
+onAuthStateChanged(auth, (user) => {
+  if (user) {
+    window.location.href = 'index.html';
+  }
+});


### PR DESCRIPTION
## Summary
- add login and registration with email/password and Google
- create activity tracker to log composting or cleanup and view recent feed
- provide dashboards for personal and global statistics
- include Firebase config stub and Firestore security rules

## Testing
- `npm test` (fails: package.json not found)


------
https://chatgpt.com/codex/tasks/task_e_6891fc378ac08331b20895decb02c5a9