### PR TITLE
Improve UI and activity tracking units

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>ImpactTrack - Dashboard</title>
+  <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
   <h1>User Dashboard</h1>

--- a/dashboard.js
+++ b/dashboard.js
@@ -25,12 +25,14 @@ function loadUserStats() {
     const stats = { compostKg: 0, cleanupKg: 0, compostMinutes: 0, cleanupMinutes: 0 };
     snapshot.forEach((doc) => {
       const data = doc.data();
+      const kg = Number(data.kg) || 0;
+      const minutes = Number(data.minutes) || 0;
       if (data.type === 'compost') {
-        stats.compostKg += data.kg || 0;
-        stats.compostMinutes += data.minutes || 0;
+        stats.compostKg += kg;
+        stats.compostMinutes += minutes;
       } else if (data.type === 'cleanup') {
-        stats.cleanupKg += data.kg || 0;
-        stats.cleanupMinutes += data.minutes || 0;
+        stats.cleanupKg += kg;
+        stats.cleanupMinutes += minutes;
       }
     });
     userStatsDiv.textContent = `Compost: ${stats.compostKg} kg, ${stats.compostMinutes} min | Cleanup: ${stats.cleanupKg} kg, ${stats.cleanupMinutes} min`;
@@ -43,12 +45,14 @@ function loadGlobalStats() {
     const stats = { compostKg: 0, cleanupKg: 0, compostMinutes: 0, cleanupMinutes: 0 };
     snapshot.forEach((doc) => {
       const data = doc.data();
+      const kg = Number(data.kg) || 0;
+      const minutes = Number(data.minutes) || 0;
       if (data.type === 'compost') {
-        stats.compostKg += data.kg || 0;
-        stats.compostMinutes += data.minutes || 0;
+        stats.compostKg += kg;
+        stats.compostMinutes += minutes;
       } else if (data.type === 'cleanup') {
-        stats.cleanupKg += data.kg || 0;
-        stats.cleanupMinutes += data.minutes || 0;
+        stats.cleanupKg += kg;
+        stats.cleanupMinutes += minutes;
       }
     });
     globalStatsDiv.textContent = `Compost: ${stats.compostKg} kg, ${stats.compostMinutes} min | Cleanup: ${stats.cleanupKg} kg, ${stats.cleanupMinutes} min`;

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>ImpactTrack - Activity Tracker</title>
+  <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
   <h1>Activity Tracker</h1>
@@ -15,11 +16,16 @@
         <option value="cleanup">Cleanup</option>
       </select>
     </label>
-    <label>
+    <div>
+      Record in:
+      <label><input type="radio" name="unit" value="minutes" checked /> Minutes</label>
+      <label><input type="radio" name="unit" value="kg" /> Kilograms</label>
+    </div>
+    <label id="minutes-label">
       Minutes:
       <input type="number" id="minutes" min="0" />
     </label>
-    <label>
+    <label id="kg-label" style="display:none;">
       Kilograms:
       <input type="number" id="kg" min="0" step="0.01" />
     </label>

--- a/index.js
+++ b/index.js
@@ -5,6 +5,9 @@ import { collection, addDoc, query, where, orderBy, limit, onSnapshot, serverTim
 const activityForm = document.getElementById('activity-form');
 const activityFeed = document.getElementById('activity-feed');
 const logoutButton = document.getElementById('logout');
+const minutesInput = document.getElementById('minutes');
+const kgInput = document.getElementById('kg');
+const unitRadios = document.querySelectorAll('input[name="unit"]');
 
 let currentUser;
 
@@ -20,17 +23,20 @@ onAuthStateChanged(auth, (user) => {
 activityForm.addEventListener('submit', async (e) => {
   e.preventDefault();
   if (!currentUser) return;
+  const unit = document.querySelector('input[name="unit"]:checked').value;
   const data = {
     userId: currentUser.uid,
     type: document.getElementById('activity-type').value,
-    minutes: Number(document.getElementById('minutes').value) || 0,
-    kg: Number(document.getElementById('kg').value) || 0,
+    minutes: unit === 'minutes' ? Number(minutesInput.value) || 0 : 0,
+    kg: unit === 'kg' ? Number(kgInput.value) || 0 : 0,
     notes: document.getElementById('notes').value,
     createdAt: serverTimestamp()
   };
   try {
     await addDoc(collection(db, 'activities'), data);
     activityForm.reset();
+    minutesInput.parentElement.style.display = '';
+    kgInput.parentElement.style.display = 'none';
   } catch (err) {
     alert(err.message);
   }
@@ -52,8 +58,23 @@ function loadFeed() {
     snapshot.forEach((doc) => {
       const data = doc.data();
       const li = document.createElement('li');
-      li.textContent = `${data.type} - ${data.minutes} min - ${data.kg} kg - ${data.notes}`;
+      const unitText = data.kg ? `${data.kg} kg` : `${data.minutes} min`;
+      li.textContent = `${data.type} - ${unitText} - ${data.notes}`;
       activityFeed.appendChild(li);
     });
   });
 }
+
+unitRadios.forEach((radio) => {
+  radio.addEventListener('change', () => {
+    if (radio.value === 'minutes') {
+      minutesInput.parentElement.style.display = '';
+      kgInput.parentElement.style.display = 'none';
+      kgInput.value = '';
+    } else {
+      kgInput.parentElement.style.display = '';
+      minutesInput.parentElement.style.display = 'none';
+      minutesInput.value = '';
+    }
+  });
+});

--- a/login.html
+++ b/login.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>ImpactTrack Login</title>
+  <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
   <h1>ImpactTrack</h1>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,47 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  color: #fff;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(-45deg, #1e3c72, #2a5298, #3a7bd5, #83a4d4);
+  background-size: 400% 400%;
+  animation: gradientBG 15s ease infinite;
+}
+
+@keyframes gradientBG {
+  0% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+}
+
+form, #activity-feed, #user-stats, #global-stats {
+  background: rgba(0, 0, 0, 0.6);
+  padding: 20px;
+  border-radius: 8px;
+  margin: 10px;
+}
+
+input, select, button {
+  margin: 5px 0;
+  padding: 8px;
+  border-radius: 4px;
+  border: none;
+}
+
+button {
+  cursor: pointer;
+  background-color: #4CAF50;
+  color: #fff;
+}
+
+button:hover {
+  background-color: #45a049;
+}
+
+h1, h2 {
+  text-shadow: 1px 1px 2px #000;
+}


### PR DESCRIPTION
## Summary
- Add animated gradient background and unified styling
- Allow activities to be logged in either minutes or kilograms
- Fix dashboard calculations to parse numeric activity stats correctly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892ea2034a08331ab48d7b6dcd8c7c8