### PR TITLE
Display user email and fix unit and activity feed

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
+  <div id="user-email" class="user-email"></div>
   <h1>User Dashboard</h1>
   <div id="user-stats"></div>
   <h2>Global Dashboard</h2>

--- a/dashboard.js
+++ b/dashboard.js
@@ -5,6 +5,7 @@ import { collection, query, where, onSnapshot } from 'https://www.gstatic.com/fi
 const userStatsDiv = document.getElementById('user-stats');
 const globalStatsDiv = document.getElementById('global-stats');
 const logoutButton = document.getElementById('logout');
+const userEmailDisplay = document.getElementById('user-email');
 let currentUser;
 
 onAuthStateChanged(auth, (user) => {
@@ -12,6 +13,9 @@ onAuthStateChanged(auth, (user) => {
     window.location.href = 'login.html';
   } else {
     currentUser = user;
+    if (userEmailDisplay) {
+      userEmailDisplay.textContent = user.email;
+    }
     loadUserStats();
     loadGlobalStats();
   }

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
+  <div id="user-email" class="user-email"></div>
   <h1>Activity Tracker</h1>
   <form id="activity-form">
     <label>

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const logoutButton = document.getElementById('logout');
 const minutesInput = document.getElementById('minutes');
 const kgInput = document.getElementById('kg');
 const unitRadios = document.querySelectorAll('input[name="unit"]');
+const userEmailDisplay = document.getElementById('user-email');
 
 let currentUser;
 
@@ -16,6 +17,9 @@ onAuthStateChanged(auth, (user) => {
     window.location.href = 'login.html';
   } else {
     currentUser = user;
+    if (userEmailDisplay) {
+      userEmailDisplay.textContent = user.email;
+    }
     loadFeed();
   }
 });
@@ -51,8 +55,8 @@ function loadFeed() {
     collection(db, 'activities'),
     where('userId', '==', currentUser.uid),
     orderBy('createdAt', 'desc'),
-    limit(10)
-  );
+      limit(5)
+    );
   onSnapshot(q, (snapshot) => {
     activityFeed.innerHTML = '';
     snapshot.forEach((doc) => {
@@ -65,16 +69,17 @@ function loadFeed() {
   });
 }
 
-unitRadios.forEach((radio) => {
-  radio.addEventListener('change', () => {
-    if (radio.value === 'minutes') {
-      minutesInput.parentElement.style.display = '';
-      kgInput.parentElement.style.display = 'none';
-      kgInput.value = '';
-    } else {
-      kgInput.parentElement.style.display = '';
-      minutesInput.parentElement.style.display = 'none';
-      minutesInput.value = '';
-    }
+  unitRadios.forEach((radio) => {
+    radio.addEventListener('change', (e) => {
+      if (!e.target.checked) return;
+      if (e.target.value === 'minutes') {
+        minutesInput.parentElement.style.display = '';
+        kgInput.parentElement.style.display = 'none';
+        kgInput.value = '';
+      } else {
+        kgInput.parentElement.style.display = '';
+        minutesInput.parentElement.style.display = 'none';
+        minutesInput.value = '';
+      }
+    });
   });
-});

--- a/styles.css
+++ b/styles.css
@@ -45,3 +45,10 @@ button:hover {
 h1, h2 {
   text-shadow: 1px 1px 2px #000;
 }
+
+.user-email {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  font-size: 0.9rem;
+}


### PR DESCRIPTION
## Summary
- Show signed-in user's email on tracker and dashboard.
- Fix unit selection to switch between minutes and kilograms.
- Limit activity feed to last five entries.

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892ed9e71948331b2edfbe3c93395b8