### PR TITLE
Ensure activity logs persist to Firestore

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import { auth, db } from './firebase-config.js';
 import { signOut, onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
-import { collection, addDoc, query, orderBy, limit, onSnapshot, Timestamp } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+import { collection, addDoc, query, orderBy, limit, onSnapshot, Timestamp, doc, setDoc } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
 
 const activityForm = document.getElementById('activity-form');
 const activityFeed = document.getElementById('activity-feed');
@@ -52,6 +52,8 @@ activityForm.addEventListener('submit', async (e) => {
   console.log('Collection path:', `users/${currentUser.uid}/logs`);
 
   try {
+    // Ensure the parent user document exists so writes to the logs subcollection succeed
+    await setDoc(doc(db, 'users', currentUser.uid), { email: currentUser.email }, { merge: true });
     const docRef = await addDoc(collection(db, 'users', currentUser.uid, 'logs'), data);
     console.log('Document written with ID: ', docRef.id);
     alert('Activity logged successfully!');

--- a/login.js
+++ b/login.js
@@ -1,5 +1,6 @@
-import { auth } from './firebase-config.js';
+import { auth, db } from './firebase-config.js';
 import { signInWithEmailAndPassword, createUserWithEmailAndPassword, GoogleAuthProvider, signInWithPopup, onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
+import { doc, setDoc } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
 
 const emailLoginForm = document.getElementById('email-login');
 const registerButton = document.getElementById('register');
@@ -35,8 +36,10 @@ googleButton.addEventListener('click', async () => {
   }
 });
 
-onAuthStateChanged(auth, (user) => {
+onAuthStateChanged(auth, async (user) => {
   if (user) {
+    // Ensure a user document exists for storing activity logs
+    await setDoc(doc(db, 'users', user.uid), { email: user.email }, { merge: true });
     window.location.href = 'index.html';
   }
 });


### PR DESCRIPTION
## Summary
- guarantee a parent user document exists before writing activity logs
- create or update a user document when authentication completes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68944e7a4cf88331b526933eac88387b