### PR TITLE
Add initial Firebase MVP with auth, activities, messaging and stats

### DIFF
--- a/auth-common.js
+++ b/auth-common.js
@@ -1,0 +1,102 @@
+import { auth, db, validateEmail, validatePassword, validateUsername } from './firebase-init.js';
+import {
+  createUserWithEmailAndPassword,
+  signInWithEmailAndPassword,
+  GoogleAuthProvider,
+  signInWithPopup,
+  onAuthStateChanged
+} from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
+import {
+  doc,
+  getDoc,
+  setDoc
+} from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+import { searchUsers, followUser, blockUser, isUsernameAvailable } from './firestore/users.js';
+import { incrementUserCount } from './firestore/stats.js';
+
+export function requireAuth() {
+  onAuthStateChanged(auth, user => {
+    if (!user) {
+      window.location.href = 'index.html';
+    }
+  });
+}
+
+export function redirectIfLoggedIn() {
+  onAuthStateChanged(auth, user => {
+    if (user) {
+      window.location.href = 'user-dashboard.html';
+    }
+  });
+}
+
+export async function signUp(username, email, password) {
+  if (!validateUsername(username)) throw new Error('Invalid username');
+  if (!validateEmail(email)) throw new Error('Invalid email');
+  if (!validatePassword(password)) throw new Error('Weak password');
+  if (!(await isUsernameAvailable(username))) throw new Error('Username taken');
+
+  const cred = await createUserWithEmailAndPassword(auth, email, password);
+  await setDoc(doc(db, 'users', cred.user.uid), {
+    username,
+    username_lowercase: username.toLowerCase(),
+    email
+  });
+  await incrementUserCount();
+  window.location.href = 'user-dashboard.html';
+}
+
+export async function logIn(email, password) {
+  await signInWithEmailAndPassword(auth, email, password);
+  window.location.href = 'user-dashboard.html';
+}
+
+export async function signInWithGoogle() {
+  const provider = new GoogleAuthProvider();
+  const result = await signInWithPopup(auth, provider);
+  await ensureUsername(result.user);
+  window.location.href = 'user-dashboard.html';
+}
+
+export async function ensureUsername(user) {
+  const ref = doc(db, 'users', user.uid);
+  const snap = await getDoc(ref);
+  if (snap.exists() && snap.data().username) return;
+  let username = '';
+  do {
+    username = prompt('Choose a username (3-20 letters, numbers, underscores):') || '';
+  } while (!validateUsername(username) || !(await isUsernameAvailable(username)));
+  await setDoc(ref, {
+    username,
+    username_lowercase: username.toLowerCase(),
+    email: user.email
+  }, { merge: true });
+  if (!snap.exists()) {
+    await incrementUserCount();
+  }
+}
+
+export function setupSearchBar() {
+  const input = document.getElementById('user-search');
+  const results = document.getElementById('search-results');
+  if (!input || !results) return;
+  input.addEventListener('change', async () => {
+    results.innerHTML = '';
+    const term = input.value.trim().toLowerCase();
+    if (!term) return;
+    const users = await searchUsers(term);
+    users.forEach(u => {
+      const div = document.createElement('div');
+      div.textContent = u.username;
+      const followBtn = document.createElement('button');
+      followBtn.textContent = 'Follow';
+      followBtn.onclick = () => followUser(u.uid);
+      const blockBtn = document.createElement('button');
+      blockBtn.textContent = 'Block';
+      blockBtn.onclick = () => blockUser(u.uid);
+      div.appendChild(followBtn);
+      div.appendChild(blockBtn);
+      results.appendChild(div);
+    });
+  });
+}

--- a/firebase-config.js
+++ b/firebase-config.js
@@ -1,9 +1,6 @@
-import { initializeApp } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
-import { getAuth } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
-import { getFirestore } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
-
-// TODO: Replace with your Firebase project's configuration
-const firebaseConfig = {
+// Firebase configuration used by the application.
+// Replace the values below with your Firebase project's details.
+export const firebaseConfig = {
   apiKey: "AIzaSyBBXlRU8GvhX6TiKA8Xr5odq5l-hEGmW7E",
   authDomain: "impact-track.firebaseapp.com",
   projectId: "impact-track",
@@ -12,7 +9,3 @@ const firebaseConfig = {
   appId: "1:1052527193780:web:e9af5b190ce97d85cc71e1",
   measurementId: "G-ZQ3QZ8SHY7"
 };
-
-const app = initializeApp(firebaseConfig);
-export const auth = getAuth(app);
-export const db = getFirestore(app);

--- a/firebase-init.js
+++ b/firebase-init.js
@@ -1,0 +1,22 @@
+import { initializeApp } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
+import { getAuth } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
+import { getFirestore } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+import { firebaseConfig } from './firebase-config.js';
+
+// Initialize Firebase
+const app = initializeApp(firebaseConfig);
+export const auth = getAuth(app);
+export const db = getFirestore(app);
+
+// Validators
+export function validateEmail(email) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+export function validatePassword(password) {
+  return /[A-Z]/.test(password) && /[a-z]/.test(password) && /\d/.test(password) && password.length >= 8;
+}
+
+export function validateUsername(username) {
+  return /^\w{3,20}$/.test(username);
+}

--- a/firestore/activities.js
+++ b/firestore/activities.js
@@ -1,0 +1,55 @@
+import { auth, db } from '../firebase-init.js';
+import {
+  collection,
+  addDoc,
+  serverTimestamp,
+  doc,
+  getDoc,
+  query,
+  where,
+  orderBy,
+  onSnapshot,
+  updateDoc,
+  arrayUnion,
+  arrayRemove
+} from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+import { updateGlobalStats } from './stats.js';
+
+export async function logActivity(type, amount, unit, note = '') {
+  const user = auth.currentUser;
+  if (!user) throw new Error('Not authenticated');
+  const userSnap = await getDoc(doc(db, 'users', user.uid));
+  const username = userSnap.exists() ? userSnap.data().username : '';
+  const ref = await addDoc(collection(db, 'activities'), {
+    userId: user.uid,
+    username,
+    type,
+    amount: Number(amount),
+    unit,
+    note,
+    createdAt: serverTimestamp(),
+    likes: []
+  });
+  await updateGlobalStats(type, Number(amount));
+  return ref;
+}
+
+export function getUserActivities(userId, callback) {
+  const q = query(
+    collection(db, 'activities'),
+    where('userId', '==', userId),
+    orderBy('createdAt', 'desc')
+  );
+  return onSnapshot(q, snap => {
+    const arr = [];
+    snap.forEach(doc => arr.push({ id: doc.id, ...doc.data() }));
+    callback(arr);
+  });
+}
+
+export async function toggleLike(activityId, userId, hasLiked) {
+  const ref = doc(db, 'activities', activityId);
+  await updateDoc(ref, {
+    likes: hasLiked ? arrayRemove(userId) : arrayUnion(userId)
+  });
+}

--- a/firestore/chats.js
+++ b/firestore/chats.js
@@ -1,0 +1,40 @@
+import { auth, db } from '../firebase-init.js';
+import {
+  doc,
+  getDoc,
+  collection,
+  addDoc,
+  serverTimestamp,
+  query,
+  orderBy,
+  onSnapshot
+} from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+import { isBlockedBetween } from './users.js';
+
+export async function sendMessage(chatId, content) {
+  const user = auth.currentUser;
+  if (!user) throw new Error('Not authenticated');
+  const chatRef = doc(db, 'chats', chatId);
+  const chatSnap = await getDoc(chatRef);
+  if (!chatSnap.exists()) throw new Error('Chat not found');
+  const data = chatSnap.data();
+  for (const uid of data.participants) {
+    if (uid !== user.uid && await isBlockedBetween(user.uid, uid)) {
+      throw new Error('Messaging blocked user');
+    }
+  }
+  await addDoc(collection(chatRef, 'messages'), {
+    senderId: user.uid,
+    formattedText: content,
+    timestamp: serverTimestamp()
+  });
+}
+
+export function listenToMessages(chatId, callback) {
+  const q = query(collection(db, 'chats', chatId, 'messages'), orderBy('timestamp'));
+  return onSnapshot(q, snap => {
+    const msgs = [];
+    snap.forEach(doc => msgs.push({ id: doc.id, ...doc.data() }));
+    callback(msgs);
+  });
+}

--- a/firestore/stats.js
+++ b/firestore/stats.js
@@ -1,0 +1,28 @@
+import { db } from '../firebase-init.js';
+import {
+  doc,
+  updateDoc,
+  increment,
+  onSnapshot,
+  setDoc
+} from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+
+const statsRef = doc(db, 'stats', 'global');
+
+// Ensure stats document exists
+setDoc(statsRef, { totalCompostKg: 0, totalCleanupMinutes: 0, totalUsers: 0 }, { merge: true });
+
+export async function updateGlobalStats(type, amount) {
+  const data = {};
+  if (type === 'compost') data.totalCompostKg = increment(amount);
+  if (type === 'cleanup') data.totalCleanupMinutes = increment(amount);
+  await updateDoc(statsRef, data);
+}
+
+export async function incrementUserCount() {
+  await updateDoc(statsRef, { totalUsers: increment(1) });
+}
+
+export function listenToGlobalStats(callback) {
+  return onSnapshot(statsRef, doc => callback(doc.data()));
+}

--- a/firestore/users.js
+++ b/firestore/users.js
@@ -1,0 +1,49 @@
+import { auth, db } from '../firebase-init.js';
+import {
+  doc,
+  setDoc,
+  serverTimestamp,
+  collection,
+  query,
+  where,
+  getDocs,
+  getDoc
+} from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+
+export async function followUser(uid) {
+  const current = auth.currentUser;
+  if (!current || current.uid === uid) return;
+  await setDoc(doc(db, `users/${current.uid}/following`, uid), { createdAt: serverTimestamp() });
+  await setDoc(doc(db, `users/${uid}/followers`, current.uid), { createdAt: serverTimestamp() });
+}
+
+export async function blockUser(uid) {
+  const current = auth.currentUser;
+  if (!current || current.uid === uid) return;
+  await setDoc(doc(db, `users/${current.uid}/blocks`, uid), { createdAt: serverTimestamp() });
+}
+
+export async function searchUsers(term) {
+  const q = query(
+    collection(db, 'users'),
+    where('username_lowercase', '>=', term),
+    where('username_lowercase', '<=', term + '\uf8ff')
+  );
+  const snap = await getDocs(q);
+  return snap.docs.map(d => ({ uid: d.id, ...d.data() }));
+}
+
+export async function isUsernameAvailable(username) {
+  const q = query(
+    collection(db, 'users'),
+    where('username_lowercase', '==', username.toLowerCase())
+  );
+  const snap = await getDocs(q);
+  return snap.empty;
+}
+
+export async function isBlockedBetween(a, b) {
+  const ab = await getDoc(doc(db, `users/${a}/blocks`, b));
+  const ba = await getDoc(doc(db, `users/${b}/blocks`, a));
+  return ab.exists() || ba.exists();
+}

--- a/global-dashboard.html
+++ b/global-dashboard.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Global Dashboard</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body id="vanta-bg">
+  <header>
+    <input type="text" id="user-search" placeholder="Search users">
+    <div id="search-results"></div>
+    <div class="user-email" id="user-email"></div>
+  </header>
+  <main id="global-stats">
+    <h1>Global Stats</h1>
+    <p>Total composted: <span id="compost-total">0</span> kg</p>
+    <p>Total cleanup: <span id="cleanup-total">0</span> minutes</p>
+    <p>Total users: <span id="users-total">0</span></p>
+  </main>
+  <script type="module">
+    import { requireAuth, setupSearchBar } from './auth-common.js';
+    import { auth } from './firebase-init.js';
+    import { listenToGlobalStats } from './firestore/stats.js';
+
+    requireAuth();
+    setupSearchBar();
+
+    auth.onAuthStateChanged(user => {
+      if (user) document.getElementById('user-email').textContent = user.email;
+    });
+
+    listenToGlobalStats(data => {
+      if (!data) return;
+      document.getElementById('compost-total').textContent = data.totalCompostKg || 0;
+      document.getElementById('cleanup-total').textContent = data.totalCleanupMinutes || 0;
+      document.getElementById('users-total').textContent = data.totalUsers || 0;
+    });
+  </script>
+</body>
+</html>

--- a/inbox.html
+++ b/inbox.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Inbox</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body id="vanta-bg">
+  <header>
+    <input type="text" id="user-search" placeholder="Search users">
+    <div id="search-results"></div>
+    <div class="user-email" id="user-email"></div>
+  </header>
+  <main>
+    <h1>Inbox</h1>
+    <div>
+      <input type="text" id="chat-id" placeholder="Chat ID">
+      <button id="load-chat">Load Chat</button>
+    </div>
+    <div id="messages"></div>
+    <div contenteditable id="message-input" style="background:#fff;color:#000;min-height:50px;margin-top:10px;"></div>
+    <button id="send-btn">Send</button>
+  </main>
+  <script type="module">
+    import { requireAuth, setupSearchBar } from './auth-common.js';
+    import { auth } from './firebase-init.js';
+    import { sendMessage, listenToMessages } from './firestore/chats.js';
+
+    requireAuth();
+    setupSearchBar();
+
+    let unsubscribe = null;
+    auth.onAuthStateChanged(user => {
+      if (user) document.getElementById('user-email').textContent = user.email;
+    });
+
+    document.getElementById('load-chat').addEventListener('click', () => {
+      const chatId = document.getElementById('chat-id').value;
+      if (unsubscribe) unsubscribe();
+      unsubscribe = listenToMessages(chatId, renderMessages);
+    });
+
+    document.getElementById('send-btn').addEventListener('click', async () => {
+      const chatId = document.getElementById('chat-id').value;
+      const content = document.getElementById('message-input').innerHTML;
+      try {
+        await sendMessage(chatId, content);
+        document.getElementById('message-input').innerHTML = '';
+      } catch(err) { alert(err.message); }
+    });
+
+    function renderMessages(msgs) {
+      const container = document.getElementById('messages');
+      container.innerHTML = '';
+      msgs.forEach(m => {
+        const div = document.createElement('div');
+        div.innerHTML = m.formattedText;
+        container.appendChild(div);
+      });
+    }
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ImpactTrack - Login</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body id="vanta-bg">
+  <header>
+    <input type="text" id="user-search" placeholder="Search users">
+    <div id="search-results"></div>
+  </header>
+  <main class="auth-container">
+    <h1>ImpactTrack</h1>
+    <form id="login-form">
+      <input type="email" id="login-email" placeholder="Email" required>
+      <input type="password" id="login-password" placeholder="Password" required>
+      <button type="submit">Log In</button>
+    </form>
+    <form id="signup-form">
+      <input type="text" id="signup-username" placeholder="Username" required>
+      <input type="email" id="signup-email" placeholder="Email" required>
+      <input type="password" id="signup-password" placeholder="Password" required>
+      <button type="submit">Sign Up</button>
+    </form>
+    <button id="google-btn">Sign in with Google</button>
+  </main>
+  <script type="module">
+    import { logIn, signUp, signInWithGoogle, setupSearchBar, redirectIfLoggedIn } from './auth-common.js';
+    redirectIfLoggedIn();
+    setupSearchBar();
+    document.getElementById('login-form').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const email = document.getElementById('login-email').value;
+      const pass = document.getElementById('login-password').value;
+      try { await logIn(email, pass); } catch(err) { alert(err.message); }
+    });
+    document.getElementById('signup-form').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const username = document.getElementById('signup-username').value;
+      const email = document.getElementById('signup-email').value;
+      const pass = document.getElementById('signup-password').value;
+      try { await signUp(username, email, pass); } catch(err) { alert(err.message); }
+    });
+    document.getElementById('google-btn').addEventListener('click', async () => {
+      try { await signInWithGoogle(); } catch(err) { alert(err.message); }
+    });
+  </script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -10,6 +10,7 @@ body {
   background: linear-gradient(-45deg, #1e3c72, #2a5298, #3a7bd5, #83a4d4);
   background-size: 400% 400%;
   animation: gradientBG 15s ease infinite;
+  overflow-x: hidden;
 }
 
 @keyframes gradientBG {
@@ -51,4 +52,29 @@ h1, h2 {
   top: 10px;
   right: 10px;
   font-size: 0.9rem;
+}
+
+body::before,
+body::after {
+  content: "";
+  position: fixed;
+  left: 0;
+  bottom: 0;
+  width: 200%;
+  height: 200px;
+  background: rgba(255, 255, 255, 0.2);
+  animation: wave 20s linear infinite;
+  transform: translateX(0);
+  z-index: -1;
+}
+
+body::after {
+  bottom: 10px;
+  opacity: 0.5;
+  animation-duration: 25s;
+}
+
+@keyframes wave {
+  from { transform: translateX(0); }
+  to { transform: translateX(-50%); }
 }

--- a/user-dashboard.html
+++ b/user-dashboard.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>User Dashboard</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body id="vanta-bg">
+  <header>
+    <input type="text" id="user-search" placeholder="Search users">
+    <div id="search-results"></div>
+    <div class="user-email" id="user-email"></div>
+  </header>
+  <main>
+    <h1>Your Activities</h1>
+    <form id="activity-form">
+      <select id="activity-type">
+        <option value="compost">Compost</option>
+        <option value="cleanup">Cleanup</option>
+      </select>
+      <input type="number" id="activity-amount" placeholder="Amount" required>
+      <select id="activity-unit">
+        <option value="kg">kg</option>
+        <option value="minutes">minutes</option>
+      </select>
+      <input type="text" id="activity-note" placeholder="Note (optional)">
+      <button type="submit">Log Activity</button>
+    </form>
+    <div id="activity-feed"></div>
+  </main>
+  <script type="module">
+    import { requireAuth, setupSearchBar } from './auth-common.js';
+    import { logActivity, getUserActivities, toggleLike } from './firestore/activities.js';
+    import { auth } from './firebase-init.js';
+
+    requireAuth();
+    setupSearchBar();
+
+    auth.onAuthStateChanged(user => {
+      if (user) {
+        document.getElementById('user-email').textContent = user.email;
+        getUserActivities(user.uid, renderActivities);
+      }
+    });
+
+    document.getElementById('activity-form').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const type = document.getElementById('activity-type').value;
+      const amount = document.getElementById('activity-amount').value;
+      const unit = document.getElementById('activity-unit').value;
+      const note = document.getElementById('activity-note').value;
+      try {
+        await logActivity(type, amount, unit, note);
+        document.getElementById('activity-form').reset();
+      } catch(err) { alert(err.message); }
+    });
+
+    function renderActivities(activities) {
+      const feed = document.getElementById('activity-feed');
+      feed.innerHTML = '';
+      activities.forEach(act => {
+        const div = document.createElement('div');
+        div.innerHTML = `<strong>${act.type}</strong> - ${act.amount} ${act.unit} ${act.note ? '- ' + act.note : ''}`;
+        const likeBtn = document.createElement('button');
+        const liked = act.likes && act.likes.includes(auth.currentUser.uid);
+        likeBtn.textContent = liked ? `Unlike (${act.likes.length})` : `Like (${act.likes.length})`;
+        likeBtn.onclick = () => toggleLike(act.id, auth.currentUser.uid, liked);
+        div.appendChild(likeBtn);
+        feed.appendChild(div);
+      });
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- set up Firebase initialization with validators and shared auth utilities
- add login/signup page plus dashboards for users, messaging, and global stats
- implement Firestore modules for activities, chats, users, and global statistics updates
- style pages with animated wave background

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689452d9f1908331a71587395ce635ef