### PR TITLE
Add activity descriptions and global feed

### DIFF
--- a/firestore/activities.js
+++ b/firestore/activities.js
@@ -47,6 +47,15 @@ export function getUserActivities(userId, callback) {
   });
 }
 
+export function getAllActivities(callback) {
+  const q = query(collection(db, 'activities'), orderBy('createdAt', 'desc'));
+  return onSnapshot(q, snap => {
+    const arr = [];
+    snap.forEach(doc => arr.push({ id: doc.id, ...doc.data() }));
+    callback(arr);
+  });
+}
+
 export async function toggleLike(activityId, userId, hasLiked) {
   const ref = doc(db, 'activities', activityId);
   await updateDoc(ref, {

--- a/global-dashboard.html
+++ b/global-dashboard.html
@@ -9,26 +9,30 @@
 
   <script type="module">
     import { requireAuth, setupNav } from './auth-common.js';
-    import { db } from './firebase-init.js';
-    import { doc, onSnapshot } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+    import { listenToGlobalStats } from './firestore/stats.js';
+    import { getAllActivities } from './firestore/activities.js';
 
     requireAuth();
     setupNav();
 
-    // Listen to your global stats docs
-    const compostRef = doc(db, 'stats', 'compost');
-    const cleanupRef = doc(db, 'stats', 'cleanup');
-    const usersRef   = doc(db, 'stats', 'users');
+    // Global stats
+    listenToGlobalStats(stats => {
+      document.getElementById('total-compost').textContent = stats.totalCompostKg;
+      document.getElementById('total-cleanup').textContent = stats.totalCleanupMinutes;
+      document.getElementById('user-count').textContent   = stats.totalUsers;
+    });
 
-    onSnapshot(compostRef, snap =>
-      document.getElementById('total-compost').textContent = snap.data().total
-    );
-    onSnapshot(cleanupRef, snap =>
-      document.getElementById('total-cleanup').textContent = snap.data().total
-    );
-    onSnapshot(usersRef, snap =>
-      document.getElementById('user-count').textContent = snap.data().count
-    );
+    // Global activity feed
+    getAllActivities(activities => {
+      const feed = document.getElementById('activity-feed');
+      feed.innerHTML = '';
+      activities.forEach(data => {
+        const item = document.createElement('div');
+        const date = data.createdAt?.toDate().toLocaleString();
+        item.textContent = `${data.username}: ${data.amount} ${data.unit} ${data.type} – ${data.note} – ${date}`;
+        feed.appendChild(item);
+      });
+    });
   </script>
 
   <h1>Global Stats</h1>
@@ -37,6 +41,9 @@
     <p>Total cleanup: <span id="total-cleanup">0</span> mins</p>
     <p>Total users: <span id="user-count">0</span></p>
   </div>
+
+  <h2>Recent Activities</h2>
+  <div id="activity-feed"></div>
 
 </body>
 </html>

--- a/inbox.html
+++ b/inbox.html
@@ -18,6 +18,8 @@
       onSnapshot,
       serverTimestamp
     } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+    import { listenToGlobalStats } from './firestore/stats.js';
+    import { getAllActivities } from './firestore/activities.js';
 
     requireAuth();
     setupNav();
@@ -52,6 +54,24 @@
         });
         document.getElementById('chat-input').value = '';
       });
+
+    // Dashboard section
+    listenToGlobalStats(stats => {
+      document.getElementById('total-compost').textContent = stats.totalCompostKg;
+      document.getElementById('total-cleanup').textContent = stats.totalCleanupMinutes;
+      document.getElementById('user-count').textContent   = stats.totalUsers;
+    });
+
+    getAllActivities(activities => {
+      const feed = document.getElementById('activity-feed');
+      feed.innerHTML = '';
+      activities.forEach(data => {
+        const item = document.createElement('div');
+        const date = data.createdAt?.toDate().toLocaleString();
+        item.textContent = `${data.username}: ${data.amount} ${data.unit} ${data.type} – ${data.note} – ${date}`;
+        feed.appendChild(item);
+      });
+    });
   </script>
 
   <h1>Inbox</h1>
@@ -61,6 +81,17 @@
     <input id="chat-input" type="text" placeholder="Type a message…" required>
     <button type="submit">Send</button>
   </form>
+
+  <section id="dashboard-section">
+    <h2>Dashboard</h2>
+    <div id="global-stats">
+      <p>Total composted: <span id="total-compost">0</span> kg</p>
+      <p>Total cleanup: <span id="total-cleanup">0</span> mins</p>
+      <p>Total users: <span id="user-count">0</span></p>
+    </div>
+    <h3>Recent Activities</h3>
+    <div id="activity-feed"></div>
+  </section>
 
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -26,6 +26,35 @@ form, #activity-feed, #user-stats, #global-stats {
   margin: 10px;
 }
 
+/* top navigation */
+nav {
+  width: 100%;
+}
+
+.nav-list {
+  list-style: none;
+  display: flex;
+  gap: 10px;
+  padding: 10px;
+  justify-content: center;
+  margin: 0;
+}
+
+.nav-list a,
+.nav-list button {
+  text-decoration: none;
+  display: inline-block;
+  background-color: #4CAF50;
+  color: #fff;
+  padding: 8px 12px;
+  border-radius: 4px;
+}
+
+.nav-list a:hover,
+.nav-list button:hover {
+  background-color: #45a049;
+}
+
 input, select, button {
   margin: 5px 0;
   padding: 8px;

--- a/user-dashboard.html
+++ b/user-dashboard.html
@@ -14,15 +14,11 @@
       setupSearchBar
     } from './auth-common.js';
 
-    import { auth, db } from './firebase-init.js';
+    import { auth } from './firebase-init.js';
     import {
-      collection,
-      addDoc,
-      serverTimestamp,
-      query,
-      orderBy,
-      onSnapshot
-    } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+      logActivity,
+      getUserActivities
+    } from './firestore/activities.js';
 
     // Protect & render nav
     requireAuth();
@@ -30,7 +26,6 @@
 
     // References
     const user = auth.currentUser;
-    const logsRef = collection(db, 'users', user.uid, 'logs');
 
     // Log form submit
     document
@@ -39,25 +34,26 @@
         e.preventDefault();
         const type   = document.getElementById('activity-type').value;
         const amount = Number(document.getElementById('activity-amount').value);
-        await addDoc(logsRef, { type, amount, created: serverTimestamp() });
+        const note   = document.getElementById('activity-desc').value.trim();
+        const unit   = type === 'compost' ? 'kg' : 'minutes';
+        await logActivity(type, amount, unit, note);
         document.getElementById('activity-amount').value = '';
+        document.getElementById('activity-desc').value = '';
       });
 
     // Display feed & stats
-    const q = query(logsRef, orderBy('created', 'desc'));
-    onSnapshot(q, snap => {
+    getUserActivities(user.uid, activities => {
       const feed = document.getElementById('activity-feed');
       feed.innerHTML = '';
       let compost = 0, cleanup = 0;
-      snap.forEach(doc => {
-        const data = doc.data();
+      activities.forEach(data => {
         const item = document.createElement('div');
+        const date = data.createdAt?.toDate().toLocaleString();
+        item.textContent = `${data.amount} ${data.unit} ${data.type} – ${data.note} – ${date}`;
         if (data.type === 'compost') {
           compost += data.amount;
-          item.textContent = `${data.amount} kg composted – ${data.created.toDate().toLocaleString()}`;
-        } else {
+        } else if (data.type === 'cleanup') {
           cleanup += data.amount;
-          item.textContent = `${data.amount} mins cleanup – ${data.created.toDate().toLocaleString()}`;
         }
         feed.appendChild(item);
       });
@@ -87,6 +83,11 @@
       id="activity-amount"
       placeholder="Amount (kg or minutes)"
       required
+    >
+    <input
+      type="text"
+      id="activity-desc"
+      placeholder="Description"
     >
     <button type="submit">Log Activity</button>
   </form>


### PR DESCRIPTION
## Summary
- Style navigation buttons in a single horizontal row.
- Enable logging activities with descriptions and record them globally.
- Show recent activities on global dashboard and embed the dashboard on the inbox page.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689469f3ddf48331958c11bc50f2b1ff